### PR TITLE
Add a Server component to ShadowProver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-	prover.iml
+prover.iml
 .idea/.name
 .idea/compiler.xml
 .idea/encodings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -38,19 +38,39 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.naveensundarg.shadow.prover.sandboxes.Sandbox</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>make-assembly</id>
+                        <id>sandbox</id>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>com.naveensundarg.shadow.prover.sandboxes.Sandbox</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <finalName>sandbox</finalName>
+                        </configuration>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>server</id>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <mainClass>com.naveensundarg.shadow.prover.Server</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <finalName>server</finalName>
+                        </configuration>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
@@ -60,8 +80,6 @@
             </plugin>
         </plugins>
     </build>
-
-
 
     <dependencies>
 
@@ -118,6 +136,17 @@
             <version>2.0.3.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.1</version>
+        </dependency>
 
     </dependencies>
 
@@ -134,4 +163,5 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
 </project>

--- a/src/main/java/com/naveensundarg/shadow/prover/Server.java
+++ b/src/main/java/com/naveensundarg/shadow/prover/Server.java
@@ -1,49 +1,93 @@
 package com.naveensundarg.shadow.prover;
 
+import com.naveensundarg.shadow.prover.core.Prover;
 import com.naveensundarg.shadow.prover.core.SnarkWrapper;
+import com.naveensundarg.shadow.prover.core.proof.Justification;
 import com.naveensundarg.shadow.prover.representations.formula.Formula;
 
 import com.naveensundarg.shadow.prover.representations.value.Value;
 import com.naveensundarg.shadow.prover.representations.value.Variable;
+import com.naveensundarg.shadow.prover.utils.Problem;
+import com.naveensundarg.shadow.prover.utils.ProblemReader;
 import com.naveensundarg.shadow.prover.utils.Reader;
 import com.naveensundarg.shadow.prover.utils.Sets;
 
 import com.google.gson.Gson;
+
 import java.util.*;
 
 import static spark.Spark.*;
 
 
 public final class Server {
+    static {
+        Prover prover = SnarkWrapper.getInstance();
+        try {
+            List<Problem> problems = ProblemReader.readFrom(Server.class.getResourceAsStream("firstorder-completness-tests.clj"));
+            problems.forEach(problem -> {
+                prover.prove(problem.getAssumptions(), problem.getGoal());
+            });
+        }
+        catch (Reader.ParsingException e) {
+            e.printStackTrace();
+            System.exit(-1);
+        }
+
+    }
     public static void main(String[] args) {
         port(7000);
-        get("/", (req, res) -> {
+
+        get("/", (req, res) -> "Hello World!");
+
+        post("/", "application/json", (req, res) -> {
             RequestPayload obj = new Gson().fromJson(req.body(), RequestPayload.class);
 
             Set<Formula> assumptions = Sets.newSet();
-            if (args.length > 1) {
-                for (int i = 0; i < obj.assumptions.length; i++) {
-                    assumptions.add(Reader.readFormulaFromString(obj.assumptions[i]));
-                }
+            for (int i = 0; i < obj.assumptions.length; i++) {
+                assumptions.add(Reader.readFormulaFromString(obj.assumptions[i]));
             }
 
             Formula goal = Reader.readFormulaFromString(obj.goal);
             SnarkWrapper prover = SnarkWrapper.getInstance();
-            ArrayList<Variable> variables = new ArrayList<>();
-            Optional<Map<Variable, Value>> justification = prover.proveAndGetBindings(assumptions, goal, variables);
-            String return_string = "{}";
-            if (justification.isPresent()) {
+
+            String return_string = "";
+            if (obj.method.equals("prove")) {
+                Optional<Justification> justification = prover.prove(assumptions, goal);
+                return_string = "{\"proved\": " + (justification.isPresent() ? "true" : "false") + "}";
+            }
+            else if (obj.method.equalsIgnoreCase("proveAndGetBinding")) {
+                Variable variable = new Variable(obj.variable);
+                Optional<Value> justification = prover.proveAndGetBinding(assumptions, goal, variable);
                 StringBuilder inner = new StringBuilder();
-                for (Variable variable : variables) {
-                    inner.append("\"").append(variable.getName()).append("\": \"").append(justification.get().get(variable)).append("\",");
+                inner.append("\"").append(variable.getName()).append("\": \"");
+                justification.ifPresent(value -> inner.append(value.toString()));
+                inner.append("\"");
+                return_string = "{\"proved\": " + (justification.isPresent() ? "true" : "false") + ", " + inner.toString() + "}";
+            }
+            else if (obj.method.equals("proveAndGetBindings")) {
+                ArrayList<Variable> variables = new ArrayList<>();
+                for (String variable : obj.variables) {
+                    variables.add(new Variable(variable));
                 }
-                return_string = "{\"variables\": {" + inner + "}}";
+                Optional<Map<Variable, Value>> justification = prover.proveAndGetBindings(assumptions, goal, variables);
+                StringBuilder inner = new StringBuilder();
+                inner.append("\"variables\": {");
+                if (justification.isPresent()) {
+                    for (Variable variable : variables) {
+                        inner.append("\"").append(variable.getName()).append("\": \"").append(justification.get().get(variable).toString()).append("\"");
+                    }
+                }
+                inner.append("}");
+                return_string = "{\"proved\": " + (justification.isPresent() ? "true" : "false") + ", " + inner.toString() + "}";
             }
             return return_string;
         });
     }
 
     public class RequestPayload {
+        public String method;
+        public String variable;
+        public String[] variables;
         public String[] assumptions;
         public String goal;
     }

--- a/src/main/java/com/naveensundarg/shadow/prover/Server.java
+++ b/src/main/java/com/naveensundarg/shadow/prover/Server.java
@@ -1,0 +1,50 @@
+package com.naveensundarg.shadow.prover;
+
+import com.naveensundarg.shadow.prover.core.SnarkWrapper;
+import com.naveensundarg.shadow.prover.representations.formula.Formula;
+
+import com.naveensundarg.shadow.prover.representations.value.Value;
+import com.naveensundarg.shadow.prover.representations.value.Variable;
+import com.naveensundarg.shadow.prover.utils.Reader;
+import com.naveensundarg.shadow.prover.utils.Sets;
+
+import com.google.gson.Gson;
+import java.util.*;
+
+import static spark.Spark.*;
+
+
+public final class Server {
+    public static void main(String[] args) {
+        port(7000);
+        get("/", (req, res) -> {
+            RequestPayload obj = new Gson().fromJson(req.body(), RequestPayload.class);
+
+            Set<Formula> assumptions = Sets.newSet();
+            if (args.length > 1) {
+                for (int i = 0; i < obj.assumptions.length; i++) {
+                    assumptions.add(Reader.readFormulaFromString(obj.assumptions[i]));
+                }
+            }
+
+            Formula goal = Reader.readFormulaFromString(obj.goal);
+            SnarkWrapper prover = SnarkWrapper.getInstance();
+            ArrayList<Variable> variables = new ArrayList<>();
+            Optional<Map<Variable, Value>> justification = prover.proveAndGetBindings(assumptions, goal, variables);
+            String return_string = "{}";
+            if (justification.isPresent()) {
+                StringBuilder inner = new StringBuilder();
+                for (Variable variable : variables) {
+                    inner.append("\"").append(variable.getName()).append("\": \"").append(justification.get().get(variable)).append("\",");
+                }
+                return_string = "{\"variables\": {" + inner + "}}";
+            }
+            return return_string;
+        });
+    }
+
+    public class RequestPayload {
+        public String[] assumptions;
+        public String goal;
+    }
+}


### PR DESCRIPTION
This also modifies the mvn build process so that it generates two jar files, one which is just the sandbox and one that is the new server, making ShadowProver easier to use in external projects that aren't written in Java.

Running the server is as simple as just running the generated jar and then accessing it through the `http://localhost:7000` endpoint.

Further work on this would be adding in a capacity to pick different provers, but I think would remain the same on the interface mostly.